### PR TITLE
Add axes.violinplot test in test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -840,25 +840,23 @@ class TestDatetimePlotting:
     def test_violinplot(self):
         np.random.seed(42)
         n_samples = 100
-        dates = [datetime.datetime(2023, 1, 1) + timedelta(days=np.random.randint(1, 30))
-                 for _ in range(n_samples)]
-        values = np.random.randn(n_samples)
-        min_length = min(len(dates), len(values))
-        dates = dates[:min_length]
-        values = values[:min_length]
+        dates_values = [(datetime(2023, 1, 1) + timedelta(days=np.random.randint(1, 15)), np.random.randn())
+                        for _ in range(n_samples)]
+        values_by_date = defaultdict(list)
+        for date, value in dates_values:
+            values_by_date[date.toordinal()].append(value)
+        date_ordinals, values = zip(*values_by_date.items())
         fig, ax = plt.subplots()
-        positions = np.arange(len(dates))
-        result = ax.violinplot(values, positions=positions, widths=0.7, showmeans=True, showextrema=True)
-        assert result is not None, "Failed to create violin plot"
-        for pos, date in zip(result['bodies'], dates):
-            assert pos.get_paths()[0].vertices[0, 0] == mpl.dates.date2num(
-                date), "Violin position does not match date"
+        result = ax.violinplot(
+            values, positions=date_ordinals, widths=0.7, showmeans=True, showextrema=True)
         ax.set_title('Violin Plot with DateTime and Timedelta Positions')
-        ax.set_xticks(positions)
-        ax.set_xticklabels([date.strftime('%Y-%m-%d') for date in dates], rotation=45, ha='right')
+        ax.set_xticks(date_ordinals)
+        ax.set_xticklabels([datetime.fromordinal(date).strftime(
+            '%Y-%m-%d') for date in date_ordinals], rotation=45, ha='right')
         ax.set_xlabel('Dates')
         ax.set_ylabel('Values')
-    
+        assert result is not None, "Failed to create violin plot"
+ 
     @mpl.style.context("default")
     def test_vlines(self):
         mpl.rcParams["date.converter"] = 'concise'

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -838,9 +838,27 @@ class TestDatetimePlotting:
     @pytest.mark.xfail(reason="Test for violinplot not written yet")
     @mpl.style.context("default")
     def test_violinplot(self):
+        np.random.seed(42)
+        n_samples = 100
+        dates = [datetime.datetime(2023, 1, 1) + timedelta(days=np.random.randint(1, 30))
+                 for _ in range(n_samples)]
+        values = np.random.randn(n_samples)
+        min_length = min(len(dates), len(values))
+        dates = dates[:min_length]
+        values = values[:min_length]
         fig, ax = plt.subplots()
-        ax.violinplot(...)
-
+        positions = np.arange(len(dates))
+        result = ax.violinplot(values, positions=positions, widths=0.7, showmeans=True, showextrema=True)
+        assert result is not None, "Failed to create violin plot"
+        for pos, date in zip(result['bodies'], dates):
+            assert pos.get_paths()[0].vertices[0, 0] == mpl.dates.date2num(
+                date), "Violin position does not match date"
+        ax.set_title('Violin Plot with DateTime and Timedelta Positions')
+        ax.set_xticks(positions)
+        ax.set_xticklabels([date.strftime('%Y-%m-%d') for date in dates], rotation=45, ha='right')
+        ax.set_xlabel('Dates')
+        ax.set_ylabel('Values')
+    
     @mpl.style.context("default")
     def test_vlines(self):
         mpl.rcParams["date.converter"] = 'concise'


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

This PR is modeled for #26864 ``axes.violinplot``.

## Points the PR addressed:

1. **Convert Dates to Ordinals:**
   > Because while doing statistics on dates can get strange fast... saying 'I want a violin plot comparing measurements taken on different dates' seems completely reasonable.

   *Code Response:* The code converts the datetime values to ordinal values (`date.toordinal()`) to make them compatible with the `violinplot`.

2. **Test Positions Instead of Stats Axis:**
   > I am now curious if at least the positioning values (position and width) work as desired (with the latter being a timedelta).

   *Code Response:* The code focuses on testing positions (`positions=date_ordinals`) rather than the stats axis.

3. **Deprioritize Fixing Units Along Stats Axis:**
   > My leaning is to deprioritize fixing units along the stats axis... ask that this test case is written to focus on positions instead for the time being.

   *Code Response:* The code doesn't explicitly address the unit conversion for statistics but prioritizes testing positions.



<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
