### PR TITLE
Remove axes.violinplot test from test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -835,12 +835,6 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.violin(...)
 
-    @pytest.mark.xfail(reason="Test for violinplot not written yet")
-    @mpl.style.context("default")
-    def test_violinplot(self):
-        fig, ax = plt.subplots()
-        ax.violinplot(...)
-
     @mpl.style.context("default")
     def test_vlines(self):
         mpl.rcParams["date.converter"] = 'concise'


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
This PR is modeled for #26864 ``Axes.violinplot``.

> If passing datetime / united data to the method does not make any sense or it should not work open a PR removing that test method and similarly reference this issue.

Supplying timedelta values doesn't make sense as **Matplotlib’s violin plot function does not natively support timedelta inputs**.


Relevant evidence is provided below:
- The official [Matplotlib Documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.violinplot.html) for violin plot does not mention support for timedelta inputs.
- The [timple package on PyPI](https://pypi.org/project/timple) notes that Matplotlib generally supports plotting of timedelta values but only as numeric values and only for limited data types. It does not natively have locators and formatters to create fancy plot ticks.
- A [Stack Overflow post](https://stackoverflow.com/questions/49848933/plot-timedelta-in-matplotlib) discusses how to plot pandas timedelta data. It suggests converting timedeltas to float or string to plot, as these are not supported currently. It also mentions a pending matplotlib feature-add to enable the plotting of TimeDeltas.
- Another [Stack Overflow post](https://stackoverflow.com/questions/15240003/matplotlib-intelligent-axis-labels-for-timedelta) provides a workaround for plotting timedelta values by converting them to seconds.
- A #8869 on the Matplotlib repository discusses the need to enable the plotting of timedeltas.

As a result, the following test fails.

## Test:

```python

import datetime
import numpy as np
import pytest
import matplotlib.pyplot as plt
import matplotlib as mpl
from datetime import timedelta
from collections import defaultdict

@pytest.mark.xfail(reason="Test for violinplot not written yet")
@mpl.style.context("default")
class TestViolinPlot:


    def test_violinplot(self):
        np.random.seed(42)
        n_samples = 100
        dates_values = [(datetime(2023, 1, 1) + timedelta(days=np.random.randint(1, 15)), np.random.randn())
                        for _ in range(n_samples)]
        values_by_date = defaultdict(list)
        for date, value in dates_values:
            values_by_date[date.toordinal()].append(value)
        date_ordinals, values = zip(*values_by_date.items())
        fig, ax = plt.subplots()
        result = ax.violinplot(
            values, positions=date_ordinals, widths=0.7, showmeans=True, showextrema=True)
        ax.set_title('Violin Plot with DateTime and Timedelta Positions')
        ax.set_xticks(date_ordinals)
        ax.set_xticklabels([datetime.fromordinal(date).strftime(
            '%Y-%m-%d') for date in date_ordinals], rotation=45, ha='right')
        ax.set_xlabel('Dates')
        ax.set_ylabel('Values')
        assert result is not None, "Failed to create violin plot"

```

## Pytest Output

```python
================================================= test session starts =================================================
platform win32 -- Python 3.11.5, pytest-7.4.3, pluggy-1.3.0
Matplotlib: 3.8.2
Freetype: 2.6.1
rootdir: C:\Users\XXXX
plugins: anyio-3.5.0, mpl-0.16.1
collected 1 item

XXXX\temp_test.py x                                                                                  [100%]

================================================= 1 xfailed in 0.88s ==================================================
```